### PR TITLE
battery_params: increase default empty cellvoltage to 3.6v

### DIFF
--- a/src/lib/battery/battery_params_deprecated.c
+++ b/src/lib/battery/battery_params_deprecated.c
@@ -43,7 +43,7 @@
  * @group Battery Calibration
  * @category system
  */
-PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.5f);
+PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.6f);
 
 /**
  * This parameter is deprecated. Please use BAT1_V_CHARGED instead.

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -21,7 +21,7 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [3.5, 3.5]
+            default: [3.6, 3.6]
 
         BAT${i}_V_CHARGED:
             description:


### PR DESCRIPTION
Based on feedback that very often the battery is used down too low.
I observed this happens consistently when the cell voltage is properly
load compensated. The default load compensation before #19429 was very
inaccurate and resulted in unpredictable estimate.
After that if there is a usable current measurement and the battery is
within expected tolerances of the default internal resistance the
compensation is pretty good and 3.5V is too low for an empty compensated
cell voltage. That was seen in various logs where the compensated
cell voltage was already dropping fast after 3.6V.

In case the voltage is not load compensated the vehicle estimates the
state of charge a bit too low which is safer than to high
especially for a default configuration.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
A clear and concise description of the problem this proposed change will solve. Or, what it will improve.
E.g. For this use case I ran into...

## Describe your solution
A clear and concise description of what you have implemented.

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
